### PR TITLE
Added MechService for improved separation of concerns

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { Mech } from './mech/mech.entity';
 import { MechController } from './mech/mech.controller';
 import { MechType } from './mechType/mechType.entity';
 import { MechWeaponHardpoint } from './mech/mechWeaponHardpoint.entity';
+import { MechService } from './mech/mech.service';
 
 @Module({
   imports: [
@@ -22,6 +23,6 @@ import { MechWeaponHardpoint } from './mech/mechWeaponHardpoint.entity';
     TypeOrmModule.forFeature([Mech, MechType, MechWeaponHardpoint]),
   ],
   controllers: [AppController, MechController],
-  providers: [AppService],
+  providers: [AppService, MechService],
 })
 export class AppModule {}

--- a/src/mech/mech.controller.ts
+++ b/src/mech/mech.controller.ts
@@ -1,34 +1,29 @@
 import { Controller, Get, Param, Post, Body, Delete } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
 import { Mech } from './mech.entity';
-import { Repository, DeleteResult } from 'typeorm';
+import { DeleteResult } from 'typeorm';
 import { MechDto } from './interfaces/mech.dto';
 import { ApiTags, ApiCreatedResponse, ApiResponse } from '@nestjs/swagger';
+import { MechService } from './mech.service';
 
 @ApiTags('mech')
 @Controller('mech')
 export class MechController {
-  constructor(
-    @InjectRepository(Mech)
-    private readonly mechRepository: Repository<Mech>,
-  ) {}
+  constructor(private readonly mechService: MechService) {}
 
   @ApiResponse({
     type: Mech,
   })
   @Get()
-  findAll(): Promise<Mech[]> {
-    return this.mechRepository.find({ relations: ['type'] });
+  findAll(): Promise<MechDto[]> {
+    return this.mechService.findAll();
   }
 
   @ApiResponse({
     type: Mech,
   })
   @Get(':id')
-  findOne(@Param('id') id: number): Promise<Mech> {
-    return this.mechRepository.findOne(id, {
-      relations: ['type', 'weaponHardpoints'],
-    });
+  findOne(@Param('id') id: number): Promise<MechDto> {
+    return this.mechService.findOne(id);
   }
 
   @ApiCreatedResponse({
@@ -37,7 +32,7 @@ export class MechController {
   })
   @Post()
   create(@Body() mechDto: MechDto): Promise<Mech> {
-    return this.mechRepository.save(mechDto);
+    return this.mechService.create(mechDto);
   }
 
   @ApiResponse({
@@ -45,6 +40,6 @@ export class MechController {
   })
   @Delete(':id')
   delete(@Param('id') id: number): Promise<DeleteResult> {
-    return this.mechRepository.delete(id);
+    return this.mechService.delete(id);
   }
 }

--- a/src/mech/mech.entity.ts
+++ b/src/mech/mech.entity.ts
@@ -9,11 +9,15 @@ import {
 import { MechType } from '../mechType/mechType.entity';
 import { MechWeaponHardpoint } from './mechWeaponHardpoint.entity';
 import { MechClass } from './interfaces/mechEnums';
+import { MechDto } from './interfaces/mech.dto';
 
 @Entity()
 export class Mech {
   @PrimaryGeneratedColumn()
   id: number;
+
+  @Column()
+  typeId: number;
 
   @ManyToOne(type => MechType)
   type: MechType;
@@ -64,4 +68,25 @@ export class Mech {
     },
   )
   weaponHardpoints: MechWeaponHardpoint[];
+
+  /**
+   * name
+   */
+  public toDTO(): MechDto {
+    return {
+      typeId: this.type.id,
+      subtype: this.subtype,
+      class: this.class,
+      stockRole: this.stockRole,
+      tonnageTotal: this.tonnageTotal,
+      tonnageFree: this.tonnageFree,
+      damageMelee: this.damageMelee,
+      damageDFA: this.damageDFA,
+      walkDistance: this.walkDistance,
+      jumpJets: this.jumpJets,
+      cost: this.cost,
+      rarity: this.rarity,
+      hardpoints: this.weaponHardpoints ? this.weaponHardpoints.map(hardpoint => hardpoint.toDTO()) : []
+    };
+  }
 }

--- a/src/mech/mech.entity.ts
+++ b/src/mech/mech.entity.ts
@@ -86,7 +86,9 @@ export class Mech {
       jumpJets: this.jumpJets,
       cost: this.cost,
       rarity: this.rarity,
-      hardpoints: this.weaponHardpoints ? this.weaponHardpoints.map(hardpoint => hardpoint.toDTO()) : []
+      hardpoints: this.weaponHardpoints
+        ? this.weaponHardpoints.map(hardpoint => hardpoint.toDTO())
+        : [],
     };
   }
 }

--- a/src/mech/mech.service.spec.ts
+++ b/src/mech/mech.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MechService } from './mech.service';
+
+describe('MechService', () => {
+  let service: MechService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MechService],
+    }).compile();
+
+    service = module.get<MechService>(MechService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/mech/mech.service.ts
+++ b/src/mech/mech.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Mech } from './mech.entity';
+import { Repository, DeleteResult } from 'typeorm';
+import { MechDto } from './interfaces/mech.dto';
+
+@Injectable()
+export class MechService {
+  constructor(
+    @InjectRepository(Mech)
+    private readonly mechRepository: Repository<Mech>,
+  ) {}
+
+  async findAll(): Promise<MechDto[]> {
+    let mechs = await this.mechRepository.find({ relations: ['type'] });
+    return mechs.map(m => m.toDTO());
+  }
+
+  async findOne(id: number): Promise<MechDto> {
+    let mech = await this.mechRepository.findOne(id, {
+      relations: ['type', 'weaponHardpoints'],
+    });
+    return mech.toDTO();
+  }
+
+  async create(mechDto: MechDto): Promise<Mech> {
+    let newMech: Mech = await this.mechRepository.save(mechDto);
+    return newMech;
+  }
+
+  async delete(id: number): Promise<DeleteResult> {
+    return await this.mechRepository.delete(id);
+  }
+}

--- a/src/mech/mechWeaponHardpoint.entity.ts
+++ b/src/mech/mechWeaponHardpoint.entity.ts
@@ -1,6 +1,7 @@
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
 import { Mech } from './mech.entity';
 import { MechBodypart, WeaponType } from './interfaces/mechEnums';
+import { MechHardpointDto } from './interfaces/mechHardpoint.dto';
 
 @Entity()
 export class MechWeaponHardpoint {
@@ -26,4 +27,14 @@ export class MechWeaponHardpoint {
     default: WeaponType.SUPPORT,
   })
   type: WeaponType;
+
+    /**
+   * name
+   */
+  public toDTO(): MechHardpointDto {
+    return {
+      bodypart: this.bodypart,
+      type: this.type
+    };
+  }
 }

--- a/src/mech/mechWeaponHardpoint.entity.ts
+++ b/src/mech/mechWeaponHardpoint.entity.ts
@@ -28,13 +28,13 @@ export class MechWeaponHardpoint {
   })
   type: WeaponType;
 
-    /**
+  /**
    * name
    */
   public toDTO(): MechHardpointDto {
     return {
       bodypart: this.bodypart,
-      type: this.type
+      type: this.type,
     };
   }
 }


### PR DESCRIPTION
## Problem

It all started when I wanted to return MechDto objects instead of the full Mech entity as a response for the mech controller (for obvious reasons).
The problem is when I started converting from MechDto to Mech entity and back `MechController` code started to get too complex.

## Solution

I added a MechService to isolate concerns and simplify things. 
`MechService` will be responsible for fetching data from DB and converting it to MechDto objects. `MechController` no longer needs to know about a Mech Repository and no longer needs to have knowledge about Mech entity's relationships like `type` and `weaponHardpoints`.

I added methods to handle conversion to DTO objects:
* Mech.toDTO()
* MechWeaponHardpoint.toDTO()

## Other changes (e.g. bug fixes, UI tweaks, small refactors)

